### PR TITLE
build: avoid librealsense installation through ros

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+    "name": "realsense2 ros",
+    "remoteUser": "ros2",
+    "initializeCommand": [
+        "docker",
+        "build",
+        "--file=./aica-package.toml",
+        "--target=development",
+        "--tag=realsense2-ros:development",
+        "."
+    ],
+    "image": "realsense2-ros:development",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/ros2/.devcontainer,type=bind,consistency=cached",
+    "workspaceFolder": "/home/ros2/.devcontainer",
+    "mounts": [
+        "source=${localWorkspaceFolder}/realsense2_camera,target=/home/ros2/ws/src/realsense2_camera,type=bind,consistency=cached"
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools-extension-pack"
+            ]
+        }
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 *.ini
 .idea/
 .vs/
-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.ini
 .idea/
 .vs/
+build/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,18 @@
+{
+    "configurations": [
+        {
+            "name": "AMD",
+            "includePath": [
+                "/opt/ros/iron/include/**",
+                "/home/ros2/ros2_ws/install/**",
+                "/home/ros2/ws/install/**",
+                "/home/ros2/ws/src/**/include"
+            ],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c17",
+            "cppStandard": "gnu++17",
+            "intelliSenseMode": "linux-gcc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,5 @@
         120
     ],
     "C_Cpp.clang_format_style": "file:/home/ros2/.clang-format",
-    "cmake.sourceDirectory": "/home/ros2/ws/src/realsense2_camera"
+    "cmake.sourceDirectory": "/home/ros2/.devcontainer/realsense2_camera"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.rulers": [
+        120
+    ],
+    "C_Cpp.clang_format_style": "file:/home/ros2/.clang-format",
+    "cmake.sourceDirectory": "/home/ros2/ws/src/realsense2_camera"
+}

--- a/aica-package.toml
+++ b/aica-package.toml
@@ -1,0 +1,39 @@
+#syntax=ghcr.io/aica-technology/package-builder:v1.1.0-rc0006
+
+[signing]
+enabled = false
+signer = "v2.0.2"
+
+[metadata]
+version = "0.0.1"
+description = "Realsense ROS"
+
+[metadata.collection]
+name = "realsense-ros"
+
+[build]
+type = "ros"
+image = "v1.0.1-iron"
+
+[build.dependencies]
+"@aica/foss/control-libraries" = "v7.4.1"
+"@aica/foss/modulo" = "v4.2.1"
+
+[build.apt-repos]
+librealsense = { uri = "https://librealsense.intel.com/Debian/apt-repo", distribution = "jammy", components = ["main"], keyring = "https://librealsense.intel.com/Debian/librealsense.pgp" }
+
+[build.packages.rs_msgs]
+source = "realsense2_camera_msgs"
+skip-sign = true
+
+[build.packages.rs_description]
+source = "realsense2_description"
+skip-sign = true
+
+[build.packages.rs_camera]
+source = "realsense2_camera"
+skip-sign = true
+
+[build.packages.rs_camera.dependencies.apt]
+librealsense2 = "2.54.1-0~realsense.9591"
+librealsense2-dev = "2.54.1-0~realsense.9591"

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -17,7 +17,6 @@
   <depend>builtin_interfaces</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
-  <depend>librealsense2</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>realsense2_camera_msgs</depend>


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
I'm adding here devcontainer configurations as well as an aica package toml that installs our desired version of librealsense through apt instead of ros. This is because the L515 we have in house is not longer supported on more recent versions of librealsense. 

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->